### PR TITLE
Add pure-claude-plugin as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".claude/plugins/pure"]
+	path = .claude/plugins/pure
+	url = https://github.com/kudima03/pure-claude-plugin


### PR DESCRIPTION
Closes #128

## What

Adds [pure-claude-plugin](https://github.com/kudima03/pure-claude-plugin) as a git submodule at `.claude/plugins/pure/`.

## Why

Gives every contributor consistent Claude Code tooling without manual setup:

- **Skill** `nuget-publish` — auto-triggered full publish workflow
- **Command** `/nuget-publish` — explicit publish trigger
- **Command** `/format` — `csharpier format . && dotnet format` from `./src`
- **Hook** `Stop` — auto-formats `.cs` files after Claude finishes

## After merging

Clone with submodule:
```bash
git clone --recurse-submodules git@github.com:kudima03/Pure.Primitives.Abstractions.git
```

Existing clones:
```bash
git submodule update --init
```